### PR TITLE
First attempt at starting to add linked_url configs

### DIFF
--- a/config/url_configs/069_national_health_and_nutrition_examination_survey.yaml
+++ b/config/url_configs/069_national_health_and_nutrition_examination_survey.yaml
@@ -4,3 +4,49 @@ expected_update_frequency: null
 tags:
   - health
   - cdc
+linked_urls:
+- url: https://www.cdc.gov/nchs/about/index.html
+  name: National Center for Health Statistics
+- url: https://www.cdc.gov/nchs/nhanes/about/index.html
+  name: About NHANES
+- url: https://www.cdc.gov/nchs/nhanes/about-data/index.html
+  name: NHANES Results and Publications
+- url: https://wwwn.cdc.gov/Nchs/Nhanes/Search/DataPage.aspx
+  name: All Demographics Data
+- url: https://www.cdc.gov/nchs/nhanes/biospecimen/index.html
+  name: Biospecimen Program
+- url: https://www.cdc.gov/nchs/nhanes/spu-specimens/index.html
+  name: Serum, Plasma, and Urine Specimens
+- url: https://www.cdc.gov/nchs/nhanes/updates/index.html
+  name: View All National Health and Nutrition Examination Survey
+- url: https://wwwn.cdc.gov/nchs/nhanes/default.aspx
+  name: About NHANES Data
+- url: https://wwwn.cdc.gov/nchs/nhanes/tutorials/default.aspx
+  name: NHANES Data Tutorials
+- url: https://www.cdc.gov/nchs/nhanes-participants/site.html
+  name: NHANES Participants
+- url: https://www.cdc.gov/nchs/nhanes-participants/index.html
+  name: Welcome to the National Health and Nutrition Examination Survey
+- url: https://www.cdc.gov/nchs/nhanes/modules/publications.html
+  name: Results and Publications
+- url: https://www.cdc.gov/nchs/nhanes/modules/data-analysis-tutorial.html
+  name: Data Analysis Tutorial
+- url: https://www.cdc.gov/nchs/nhanes/modules/webinars.html
+  name: Webinars
+- url: https://www.cdc.gov/nchs/nhanes/updates/growth-charts.html
+  name: Growth Charts
+- url: https://wwwn.cdc.gov/nchs/nhanes/ProposalGuidelines.aspx
+  name: Proposal Guidelines
+- url: https://wwwn.cdc.gov/nchs/data/nhanes/survey_contents.pdf
+  name: Survey Contents Brochure
+- url: https://www.cdc.gov/nchs/products/databriefs/db519.htm
+  name: >- 
+    Anemia Prevalence: United States, August 2021 - August 2023
+- url: https://wwwn.cdc.gov/Nchs/Nhanes/Search/DataPage.aspx?Component=Laboratory&CycleBeginYear=2001
+  name: Caffeine & Caffeine Metabolites - Urine (Surplus) (SSCAFE_B 2001-2002)
+- url: https://wwwn.cdc.gov/Nchs/Nhanes/Search/DataPage.aspx?Component=Laboratory&CycleBeginYear=1999
+  name: Caffeine & Caffeine Metabolites - Urine (Surplus) (SSCAFE_A 1999-2000)
+- url: https://wwwn.cdc.gov/Nchs/Nhanes/Search/DataPage.aspx?Component=Laboratory&Cycle=2017-2020
+  name: Sex Steroid Hormone Panel - Serum (P_TST 2017-March 2020)
+- url: https://wwwn.cdc.gov/Nchs/Nhanes/Search/DataPage.aspx?Component=Laboratory&CycleBeginYear=2017
+  name: Sex Steroid Hormone Panel - Serum (Surplus) (SSTST_J 2017-2018)

--- a/scripts/example_link_trimmer.py
+++ b/scripts/example_link_trimmer.py
@@ -1,0 +1,66 @@
+# Bulk trimming down of JSON of links from each page, to get a more manageable list of links
+#  and desriptions of pages to monitor as "linked lists" within the overall tracker.
+#  Prioritization decisions:
+#    1. Emphasize, but not necessarily limit to, actual data sources, especially data *files*.
+#    2. PDFs and supporting/explanatory information also important.
+#    3. Duplicate links are not needed; just pick one version with the most useful description.
+#    4. Within page navigation links (with a `#`) are not needed.
+#    5. Ignore links to social media accounts
+
+import json
+
+with open('069_national_health_and_nutrition_examination_survey.json') as f:
+    input_json = json.load(f)
+
+social_media_exclusion_list = (
+    'https://www.snapchat.com',
+    'https://www.twitter.com',
+    'https://twitter.com',
+    'https://www.x.com'
+    'https://x.com',
+    'https://www.facebook.com',
+    'https://www.instagram.com',
+    'https://www.linkedin.com',
+    'https://www.youtube.com',
+    'https://www.pinterest.com'
+)
+
+out_links = {}
+
+for link in input_json['links']:
+    # Exclusion criteria we won't keep in the list at all
+    if link['url'].startswith(social_media_exclusion_list):
+        continue
+    if '#' in link['url']: # Omit within-page navigation tags
+        continue
+    if link['text'] == '[No text]':
+        continue
+    if link['text'] == 'Home':
+        continue
+
+    if link['url'] in out_links.keys():
+        if link['text'] not in out_links[link['url']]:
+            out_links[link['url']].append(link['text'])
+    else:
+        out_links[link['url']] = [link['text']]
+
+out_links
+
+# Stitch to YAML
+## This YAML will still need to be manually inspected for duplicate descriptions:
+## When the same link has appeared with different text on the page, that will here be added
+##  as separate lines with the `name: ` key, which is not valid YAML. (Hence why this is manually
+##  written as text instead of using a YAML library.)
+## This also doesn't yet handle other kinds of text parsing and formatting issues, such as accent/punctuation
+##  encoding or strings that themselves include a colon/dash/other YAML reserved character
+
+out_yaml = 'linked_urls:\n'
+for x in out_links:
+    out_yaml += f'- url: {x}\n'
+    for name in out_links[x]:
+        out_yaml += f'  name: {name}\n'
+
+out_yaml
+
+with open('069_national_health_and_nutrition_examination_survey.yaml', 'w') as file:
+    file.write(out_yaml)


### PR DESCRIPTION
I am still not 100% clear on the expected conventions of what linked_urls are or are not desirable to include in this phase of the work, but I started with my first config here and the corresponding JSON file of all the scraped page links to try and get a (more) scalable first attempt.

Included:

- Basic example of the cleaning/processing logic I used to take in the JSON, consolidate duplicates, auto-remove irrelevant links on some basic criteria, etc. This script, `example_link_trimmer.py`, is currently relatively hard-coded for a single JSON file example, but any valuable business logic from it could probably be extracted into the existing processing scripts.
- One initial config with this applied, but some additional manual changes and processing after the fact.