### PR TITLE
Initial setup of Flask web application framework

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ jinja2>=3.1.2
 beautifulsoup4>=4.12.2
 tqdm>=4.66.1
 duckdb>=0.9.2
+flask>=3.1.0

--- a/src/multi_monitor/app.py
+++ b/src/multi_monitor/app.py
@@ -5,7 +5,7 @@ from .db import MonitorDB
 # current module (__name__) as argument.
 app = Flask(__name__)
 
-db = MonitorDB('../data/monitor.db')
+db = MonitorDB('../data/monitor.db', read_only=True)
 
 # The route() function of the Flask class is a decorator, 
 # which tells the application which URL should call 
@@ -23,7 +23,9 @@ def landing_home():
         stale_collections_count=3
     )
 
-@app.route('')
+@app.route('/resources')
+def list_resources():
+    return 'Resources list will go here'
 
 # main driver function
 if __name__ == '__main__':

--- a/src/multi_monitor/app.py
+++ b/src/multi_monitor/app.py
@@ -1,0 +1,33 @@
+from flask import Flask, render_template
+from .db import MonitorDB
+
+# Flask constructor takes the name of 
+# current module (__name__) as argument.
+app = Flask(__name__)
+
+db = MonitorDB('../data/monitor.db')
+
+# The route() function of the Flask class is a decorator, 
+# which tells the application which URL should call 
+# the associated function.
+@app.route('/')
+# ‘/’ URL is bound with hello_world() function.
+def landing_home():
+
+    return render_template(
+        'multi_page/landing_page.html',
+        data_collections_count=100,
+        data_resources_count=10000,
+        unavailable_collections_count=1,
+        partially_unavailable_collections_count=2,
+        stale_collections_count=3
+    )
+
+@app.route('')
+
+# main driver function
+if __name__ == '__main__':
+
+    # run() method of Flask class runs the application 
+    # on the local development server.
+    app.run()

--- a/src/multi_monitor/app.py
+++ b/src/multi_monitor/app.py
@@ -25,7 +25,37 @@ def landing_home():
 
 @app.route('/resources')
 def list_resources():
-    return 'Resources list will go here'
+    results = db._read_query(
+        """
+        SELECT * FROM resources
+        """)
+    return results
+
+@app.route('/resources/<resource_id>')
+def show_resource_details(resource_id: str):
+    # TODO: Make as safer executition string.
+    results = db._read_query(
+    f"""
+    SELECT * FROM resources
+    WHERE id = '{resource_id}';
+    """
+    )
+    column_headers = [field[0] for field in results[0]]
+    body = results[1][0]
+    
+    return render_template(
+        "multi_page/resource_detail.html",
+        resource = {
+            'name': body[1],
+            'type': body[2],
+            'url': body[3],
+            # "metadata" field in [4]
+            'created_at': body[5]
+        }
+    )
+
+
+
 
 # main driver function
 if __name__ == '__main__':

--- a/src/multi_monitor/db.py
+++ b/src/multi_monitor/db.py
@@ -28,9 +28,11 @@ class MonitorDB:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         
         # Initialize connection
-        self.read_only = True
+        self.read_only = read_only
         self.conn = duckdb.connect(str(self.db_path), read_only = read_only)
-        self._create_tables()
+        # TODO: instantiate "cursors" for thread safety on connection?
+        if not read_only:
+            self._create_tables()
     
     def _create_tables(self):
         """Create database tables if they don't exist."""
@@ -542,5 +544,6 @@ class MonitorDB:
                   is set in read-only mode. Did you create your MonitorDB with read_only = True?""")
         
         result = self.conn.execute(query_string)
-        return result.fetchall()
+        # TODO: Refactor returned result data format
+        return [result.description, result.fetchall()]
 

--- a/src/multi_monitor/templates/multi_page/landing_page.html
+++ b/src/multi_monitor/templates/multi_page/landing_page.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Federal Dataset Monitoring Service</title>
+</head>
+
+<body>
+    <div class="header_block">
+        <h1>Federal Dataset Monitoring Service</h1>
+    </div>
+
+    <div class="intro_blurb">
+        We are currently monitoring {{data_collections_count}} data collections publicly published by the U.S. Government, totalling some {{data_resources_count}} different data resources.
+
+        Currently, 🔴 {{unavailable_collections_count}} collections are completely unavailable, 🟠 {{partially_unavailable_collections_count}} are partially unavailable, and 🟡 {{stale_collections_count}} have not been updated as expected.
+
+    </div>
+
+    <div class="latest_statuses_block">
+
+    </div>
+</body>

--- a/src/multi_monitor/templates/multi_page/resource_detail.html
+++ b/src/multi_monitor/templates/multi_page/resource_detail.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Federal Dataset Monitoring Service</title>
+</head>
+
+<body>
+    <h2>{{resource.name}}</h2>
+    <b>URL: </b> <a href = "{{resource.url}}">{{resource.url}}</a>
+    <b>Type: </b> {{resource.type}}
+    <b>Created at: </b> {{resource.created_at}}
+<br>
+    <a href = "/resources/">Back to all resources</a>
+</body>


### PR DESCRIPTION
This PR is meant to set up the initial scaffolding for a web application that can:

1. Read data from the existing DuckDB database.
2. Process that data using a Python/Flask web app framework.
3. Serve up Jinja HTML template pages for different web app endpoints, dynamically populated by the Flask server logic.

The functionality so far is very minimal, and not yet ready for any sort of real deployment. But since it presently does not introduce any code conflicts, it may be worth setting this up for initial review and merge to test out the "yak-shaving" set up steps, to make sure that other contributors can start to check out and run the application well enough to allow for them to test and contribute.

### Not currently included, worth questioning from reviewers:

1. Does the addition of the `flask` dependency translate to running the application `app.py` file correctly? Or is other project config needed?
2. What instructions need to be added to or changed in the `README` or other supporting documentation?
3. Should more changes be set up in the database connector logic up-front to ensure consistent future development, or can those be added iteratively as needed?