### PR TITLE
Scaffolding enhancements to Flask app outline

### DIFF
--- a/src/multi_monitor/app.py
+++ b/src/multi_monitor/app.py
@@ -13,11 +13,17 @@ db = MonitorDB('../data/monitor.db', read_only=True)
 @app.route('/')
 # ‘/’ URL is bound with hello_world() function.
 def landing_home():
+    results = db._read_query(
+        """
+        SELECT count(*) as data_resources_count FROM resources
+        """)
+
+    data_resources_count = results[0]['data_resources_count']
 
     return render_template(
         'multi_page/landing_page.html',
         data_collections_count=100,
-        data_resources_count=10000,
+        data_resources_count=data_resources_count,
         unavailable_collections_count=1,
         partially_unavailable_collections_count=2,
         stale_collections_count=3

--- a/src/multi_monitor/db.py
+++ b/src/multi_monitor/db.py
@@ -544,6 +544,8 @@ class MonitorDB:
                   is set in read-only mode. Did you create your MonitorDB with read_only = True?""")
         
         result = self.conn.execute(query_string)
-        # TODO: Refactor returned result data format
-        return [result.description, result.fetchall()]
+        column_names = [column[0] for column in result.description]
+        list_of_objects = [dict(zip(column_names, row)) for row in result.fetchall()]
+        
+        return list_of_objects
 

--- a/src/multi_monitor/static/styles/styles.css
+++ b/src/multi_monitor/static/styles/styles.css
@@ -1,0 +1,262 @@
+/* Reference styling courtesy of Trump Costs America: 
+https://trumpcostsamerica.com/ 
+*/
+
+:root {
+    text-rendering: optimizeLegibility;
+    min-width: 360px;
+    scroll-behavior: smooth;
+
+    overscroll-behavior: none;
+    
+}
+
+body {
+    position: relative;
+    height: 100%;
+    min-height: 100%;
+    font-family: Inter, Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif;
+    font-weight: 400;
+    color: #212427;
+    margin: 0;
+    padding: 0;
+    width: 100vw;
+    max-width: 100vw;
+    min-width: 360px;
+    overflow-x: hidden;
+    overflow-y: scroll;
+    overscroll-behavior: none;
+}
+
+
+#header{
+    background: white;
+    width: 100%;
+    z-index: 0;
+}
+
+h1 {
+    max-width: 80%;
+    font-size: clamp(1.7em, calc(5vw), 4.3em);
+    font-weight: 400;
+    text-align: left;
+    line-height: 1.15em;
+    margin-top: 1em;
+    margin-right: auto;
+    margin-left: auto;
+    margin-bottom: 0;
+
+}
+
+h1 strong{
+    font-weight: 800;
+}
+
+#jobsKilled {
+    font-weight: 900;
+    color: black;
+    line-height: 1.1em;
+    font-variant-numeric: tabular-nums;
+    text-decoration: underline;
+    text-decoration-color: red;
+}
+
+#resourcesCountLink {
+    font-weight: 900;
+    color: black;
+    line-height: 1.1em;
+    font-variant-numeric: tabular-nums;
+    text-decoration: underline;
+    text-decoration-color: blue;
+}
+
+
+#storyGallery {
+    position: relative;
+    min-height: 55%;
+    max-height: 55%;
+    min-height: 55svh;
+    max-height: 55svh;
+    background: #fff;
+    max-width: 100vw;
+    z-index: 4;
+    overflow: hidden;
+}
+
+
+.story{
+    display: none;
+    position: absolute;
+    height: min-content;
+    width: 45vmin;
+    max-width: 400px;    
+    margin: 0;
+    padding: calc(0.3vw + 0.8lvh + 1vmin);
+    font-size: clamp(14px, calc(0.3vw + 0.5lvh + 1vmin), calc(0.3vw + 0.5lvh + 1vmin));
+    font-family: 'Iowan Old Style', 'Palatino Linotype', 'URW Palladio L', P052, serif;
+    background: white;
+    top: 20px;
+    will-change: left;
+    transition: transform 0.25s ease-out, border 0.25s ease-out, color 0.25s ease-out;
+    z-index: 4;
+    color:  #7e0f0f;
+    border: 3px solid #7e0f0f;
+}
+
+
+
+.story:hover, .story:active{
+    z-index: 10000 !important;
+    color:  #00112b;
+    border-color: #00112b;
+    transform: scale(1.2,1.2);
+}
+
+#message{
+    display: block;
+    margin: 0 auto;
+    width: 90%;
+    max-width: 35em;
+    font-size: clamp(16px, calc(0.3vw + 1.0vh + 1vmin), calc(0.3vw + 1.0vh + 1vmin));
+    background: #fff;
+
+}
+
+#message p{
+    font-weight: 400;
+    max-width: 900px;
+    margin: 0 auto 1em auto;
+    line-height: 1.1em;
+}
+
+.actionButtons{
+    display: flex;
+    justify-content: space-around; 
+    align-items: center; 
+    flex-direction: row; 
+    flex-wrap: wrap-reverse; 
+    align-content: flex-start;
+    gap: 1em;
+    width: 80%;
+    margin: 0 auto 2em;
+}
+
+.actionButton{
+    display: block;
+    padding: 1em;
+    font-size: 1em;
+    text-align: center;
+    text-transform: uppercase;
+    font-weight: 500;
+    color: #fff;
+    background: #00112b; 
+    border: 3px solid #00112b; 
+    cursor:pointer;
+    flex-grow: 1;
+    text-decoration: none;
+}
+
+.actionButton:hover{
+    color: #00112b;
+    background: #fff;
+}
+
+.actionList{
+    display: flex;
+    justify-content: center; 
+    align-items: stretch; 
+    flex-direction: row; 
+    flex-wrap: wrap; 
+    align-content: flex-start;
+    gap: 1em;
+    width: 80%;
+    margin: 0 auto 2em;
+}
+
+.actionListItem{
+    display: block;
+    max-width: 25em;
+    flex-grow: 1;
+    background: #eee;
+    padding: 1em 0;
+}
+
+.actionListItem a{
+    text-decoration: none;
+}
+
+.actionListButton{
+    text-decoration: none;
+    padding: 1em;
+    margin: .5em auto;
+    font-size: 1em;
+    max-width: 16em;
+    text-align: center;
+    text-transform: uppercase;
+    font-weight: 500;
+    color: #fff;
+    background: #00112b;
+    border: 3px solid #00112b; 
+    cursor: pointer;
+}
+.actionListButton:hover{
+    color: #00112b;
+    background: transparent;
+}
+
+.actionListDescription{
+    display: block;
+    margin: 0 auto;
+    padding: .5em;
+    font-size: 1.15em;
+    text-align: left;
+    font-weight: 400;
+    color: #00112b;
+    width: 90%;
+    max-width: 22em;
+}
+
+.jump{
+    text-align: right;
+}
+.jump a{
+    color: #fff;
+    text-decoration: none;
+}
+.jump a:hover{
+    color: #ff6f19;
+    text-decoration: none;
+}
+
+#citations{
+    background:#212427;
+    margin-top: 2em;
+    max-width: 100%;
+    padding: 4vw;
+    color: white;
+}
+
+#citations a{
+    color: red;
+}
+
+#citations a:hover{
+    color: #ff6f19;
+}
+
+.citation {
+    max-width: 1440px;
+    margin: 1em auto;
+    color: white;
+}
+
+#privacyLink{
+    text-align: right;
+}
+
+#privacyLink a{
+    font-size: 24px;
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 8px;
+}

--- a/src/multi_monitor/templates/multi_page/landing_page.html
+++ b/src/multi_monitor/templates/multi_page/landing_page.html
@@ -1,18 +1,24 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Federal Dataset Monitoring Service</title>
+    <title>America's Essential Data</title>
+<!--     <link rel="stylesheet" type="text/css" href="styles.css">
+ -->
+ <link rel= "stylesheet" type= "text/css" href= "{{ url_for('static',filename='styles/styles.css') }}">
+
 </head>
 
 <body>
     <div class="header_block">
-        <h1>Federal Dataset Monitoring Service</h1>
+        <h1>America's Essential Data</h1>
     </div>
 
     <div class="intro_blurb">
-        We are currently monitoring {{data_collections_count}} data collections publicly published by the U.S. Government, totalling some {{data_resources_count}} different data resources.
+        <h1></h1>
+        We are currently monitoring 
+        <a href="/resources/" id="resourcesCountLink">{{data_resources_count}}</a> data resources publicly published by the U.S. Government.
 
-        Currently, 🔴 {{unavailable_collections_count}} collections are completely unavailable, 🟠 {{partially_unavailable_collections_count}} are partially unavailable, and 🟡 {{stale_collections_count}} have not been updated as expected.
+        Currently, 🔴 {{unavailable_collections_count}} are completely unavailable, 🟠 {{partially_unavailable_collections_count}} are partially unavailable, and 🟡 {{stale_collections_count}} have not been updated as expected.
 
     </div>
 

--- a/src/multi_monitor/templates/multi_page/resource_detail.html
+++ b/src/multi_monitor/templates/multi_page/resource_detail.html
@@ -6,9 +6,16 @@
 
 <body>
     <h2>{{resource.name}}</h2>
-    <b>URL: </b> <a href = "{{resource.url}}">{{resource.url}}</a>
-    <b>Type: </b> {{resource.type}}
-    <b>Created at: </b> {{resource.created_at}}
+    <b>URL: </b> <a href = "{{resource.url}}">{{resource.url}}</a><br>
+    <b>Type: </b> {{resource.type}} <br>
+    <b>Created at: </b> {{resource.created_at}} <br>
 <br>
     <a href = "/resources/">Back to all resources</a>
+
+    {% if status_history %}
+    <h3>Status history</h3>
+        {% for status in status_history %}
+            {% include 'multi_page/status_preview.html' %}
+        {% endfor %}
+    {% endif %}
 </body>

--- a/src/multi_monitor/templates/multi_page/resource_list.html
+++ b/src/multi_monitor/templates/multi_page/resource_list.html
@@ -1,0 +1,6 @@
+<body>
+<h1>All tracked resources</h1>
+{% for resource in resources %}
+    {% include 'multi_page/resource_preview.html' %}
+{% endfor %}
+</body>

--- a/src/multi_monitor/templates/multi_page/resource_preview.html
+++ b/src/multi_monitor/templates/multi_page/resource_preview.html
@@ -1,0 +1,7 @@
+<div class = "resource_preview">
+    <h3>{{resource.name}}</h3>
+    <b>URL: </b> <a href = "{{resource.url}}">{{resource.url}}</a><br>
+    <b>Type: </b> {{resource.type}} <br>
+    <b>Created at: </b> {{resource.created_at}} <br>
+    <a href="{{resource.id}}">See more</a>
+</div>

--- a/src/multi_monitor/templates/multi_page/status_preview.html
+++ b/src/multi_monitor/templates/multi_page/status_preview.html
@@ -1,0 +1,4 @@
+<div class = "resource_status">
+    <h4>{{status.checked_at}}</h4>
+    <b>Status: </b> {{status.status}}
+</div>


### PR DESCRIPTION
Despite what the branch name might suggest, this PR does not do much to add desirable visual styling to the existing Flask app, or even just the landing page. Instead, it includes a reference example of how CSS _could_ be applied, drawing from the [Trump Costs America](https://trumpcostsamerica.com/) page and its CSS styling (with the authors' permission).

So more generally, this PR includes routing and organizational improvements to:

1. Demonstrate CSS file sourcing from the `static` directory
2. Improve the structure of arbitrary data returned from the DB into a list of dicts (much better to serialize to a JavaScript-friendly array of JSON objects)
3. Add some new app/API endpoints for returning different types of content and data
4. Add more HTML templates for showing how different types of data and objects can be represented at different urls.

This may all still be thrown out in favor of a different server framework entirely, if that makes more sense with our evolving frontend strategy. But the hope here is to show a bit more in practice how the actual contents of `monitor.db` could be represented in different pages and sub-components.