### PR TITLE
VS Code: Add default formatters, recommend auto-format extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ htmlcov/
 
 # IDE
 .idea/
-.vscode/
 *.swp
 *.swo
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": [
+    "EditorConfig.EditorConfig",
+    "esbenp.prettier-vscode",
+    "ms-python.black-formatter",
+    "ms-python.python",
+    "ms-python.vscode-pylance"
+  ],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": []
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,9 +6,11 @@
   "recommendations": [
     "EditorConfig.EditorConfig",
     "esbenp.prettier-vscode",
+    "monosans.djlint",
     "ms-python.black-formatter",
     "ms-python.python",
-    "ms-python.vscode-pylance"
+    "ms-python.vscode-pylance",
+    "samuelcolvin.jinjahtml"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,10 @@
   },
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"
+  },
+  "[jinja-html]": {
+    "djlint.enableLinting": true,
+    "djlint.profile": "jinja",
+    "editor.defaultFormatter": "monosans.djlint"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,11 @@
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[jinja-html]": {
+    "djlint.enableLinting": true,
+    "djlint.profile": "jinja",
+    "editor.defaultFormatter": "monosans.djlint"
+  },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
@@ -19,10 +24,5 @@
   },
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"
-  },
-  "[jinja-html]": {
-    "djlint.enableLinting": true,
-    "djlint.profile": "jinja",
-    "editor.defaultFormatter": "monosans.djlint"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,9 +4,10 @@
   "[css]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "[html]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
+  // Temporarily removed to work out formatting for Jinja templates
+  // "[html]": {
+  //   "editor.defaultFormatter": "esbenp.prettier-vscode"
+  // },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "editor.formatOnSave": true,
+
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "black==25.1.0",  # For linting
+    "djlint==1.36.4",  # For formatting and linting
     "pytest==8.3.5",  # For testing
     "pytest-cov==6.0.0",  # For test coverage
     "ruff==0.9.10",  # For linting


### PR DESCRIPTION
This pull request adds a workspace configuration for people who use Visual Studio Code, to help us standardize on code formatting for various file types. It sets default formatters and recommends plugins that handle auto-formatting.