### PR TITLE
Add latest status for each resource to resource preview

### DIFF
--- a/data/view_definitions/v_latest_resource_status.sql
+++ b/data/view_definitions/v_latest_resource_status.sql
@@ -1,0 +1,13 @@
+CREATE MATERIALIZED VIEW v_latest_resource_status AS (
+    WITH rank_list AS(
+        SELECT
+            resource_id,
+            id,
+            checked_at, 
+            rank() OVER (PARTITION BY resource_id ORDER BY checked_at desc) as ranking
+        FROM resource_status
+    )
+    SELECT *
+    FROM rank_list
+    WHERE ranking = 1
+);

--- a/data/view_definitions/v_resource_previews.sql
+++ b/data/view_definitions/v_resource_previews.sql
@@ -1,0 +1,17 @@
+CREATE VIEW v_resource_previews AS (
+    SELECT 
+        resources.*,
+        resource_status.id as latest_status_id,
+        resource_status.checked_at as latest_status_timestamp,
+        resource_status.status as latest_status,
+        resource_status.status_code as latest_status_code,
+        resource_status.status_text as latest_status_text
+    FROM
+        resources
+    LEFT JOIN
+        v_latest_resource_status
+        ON resources.id = v_latest_resource_status.resource_id
+    LEFT JOIN
+        resource_status
+        ON v_latest_resource_status.id = resource_status.id
+);

--- a/src/americas_essential_data/web/blueprints/data_and_tools/blueprint.py
+++ b/src/americas_essential_data/web/blueprints/data_and_tools/blueprint.py
@@ -30,8 +30,8 @@ def resources_index(page=1):
     page = max(1, page)  # Ensure page is at least 1
     per_page = 50  # Number of resources per page
 
-    # Get all resources
-    all_resources_raw = ResourceRepository(db_instance).all()
+    # Get all resources from the view that includes joined preview information
+    all_resources_raw = ResourceRepository(db_instance).all_previews()
 
     # Convert to dot notation objects
     all_resources = [DotDict(resource) for resource in all_resources_raw]

--- a/src/americas_essential_data/web/blueprints/data_and_tools/templates/data_and_tools/resources/_partials/resource_preview.html.jinja
+++ b/src/americas_essential_data/web/blueprints/data_and_tools/templates/data_and_tools/resources/_partials/resource_preview.html.jinja
@@ -19,6 +19,12 @@
         <th class="resource-preview__field-header">Created at</th>
         <td>{{ resource.created_at }}</td>
       </tr>
+      {% if resource.latest_status %}
+        <tr>
+          <th class="resource-preview__field-header">Latest status</th>
+          <td>{{ resource.latest_status }}, checked at {{ resource.latest_status_timestamp }}</td>
+        </tr>
+      {% endif %}
     </tbody>
   </table>
 </article>

--- a/src/americas_essential_data/web/data_access/resource.py
+++ b/src/americas_essential_data/web/data_access/resource.py
@@ -20,3 +20,10 @@ class ResourceRepository:
             """,
             [id],
         )
+
+    def all_previews(self):
+        return self.db.query(
+            """
+            SELECT * FROM v_resource_previews
+            """
+        )

--- a/src/americas_essential_data/web/data_access/resource_status.py
+++ b/src/americas_essential_data/web/data_access/resource_status.py
@@ -6,6 +6,7 @@ class ResourceStatusRepository:
         self.db = db
 
     def find_latest_changes(self):
+        # TODO: Swap this out with read of the new materialized view?
         return [
             dict(
                 dataset="Workplace Fatality Investigations Data",


### PR DESCRIPTION
I can't test this without a working local database (and also watch out for the `beta` schema vs prod), but this PR _should_ implement all of the changes needed to have the latest status result blurb show up on the Resources index page preview for each resource.

This includes:

- New SQL files for the convenience views I created in the database to reference these (instead of just having them as stored complex queries in the server code).
- Updates to the server code to fetch from this new view and serve the additional status columns.
- Updates to the JINJA template code for the preview to use a (very minimalist) display of the status; the extra polish and information can still be saved for the details page separately.