### PR TITLE
Add collections pages

### DIFF
--- a/data/view_definitions/v_collection_previews.sql
+++ b/data/view_definitions/v_collection_previews.sql
@@ -1,0 +1,36 @@
+CREATE VIEW beta.v_collection_previews AS (
+    WITH resource_counts AS (
+        SELECT 
+            collection_id,
+            count(distinct(resource_id)) as linked_resources_count
+        FROM
+            beta.collection_resources
+        GROUP BY 1
+    ),
+    primary_resources AS (
+        SELECT
+            collection_id,
+            resource_id
+        FROM
+            beta.collection_resources
+        WHERE is_primary = True
+        -- TODO: Need to enforce that there is not more than 1 "primary" per collection
+    )
+    SELECT 
+        collections.*,
+        resource_counts.linked_resources_count,
+        resources.url as primary_resource_url
+        -- TODO: Add here any business logic for determining overall collection status
+        --  from the constiuent resource statuses.
+    FROM
+        beta.collections
+    LEFT JOIN
+        resource_counts
+        ON collections.id = resource_counts.collection_id
+    LEFT JOIN
+        primary_resources
+        ON collections.id = primary_resources.collection_id
+    LEFT JOIN
+        beta.resources
+        ON primary_resources.resource_id = resources.id
+);

--- a/data/view_definitions/v_latest_resource_status.sql
+++ b/data/view_definitions/v_latest_resource_status.sql
@@ -1,0 +1,13 @@
+CREATE MATERIALIZED VIEW v_latest_resource_status AS (
+    WITH rank_list AS(
+        SELECT
+            resource_id,
+            id,
+            checked_at, 
+            rank() OVER (PARTITION BY resource_id ORDER BY checked_at desc) as ranking
+        FROM resource_status
+    )
+    SELECT *
+    FROM rank_list
+    WHERE ranking = 1
+);

--- a/data/view_definitions/v_resource_previews.sql
+++ b/data/view_definitions/v_resource_previews.sql
@@ -1,0 +1,17 @@
+CREATE VIEW v_resource_previews AS (
+    SELECT 
+        resources.*,
+        resource_status.id as latest_status_id,
+        resource_status.checked_at as latest_status_timestamp,
+        resource_status.status as latest_status,
+        resource_status.status_code as latest_status_code,
+        resource_status.status_text as latest_status_text
+    FROM
+        resources
+    LEFT JOIN
+        v_latest_resource_status
+        ON resources.id = v_latest_resource_status.resource_id
+    LEFT JOIN
+        resource_status
+        ON v_latest_resource_status.id = resource_status.id
+);

--- a/src/americas_essential_data/web/blueprints/data_and_tools/blueprint.py
+++ b/src/americas_essential_data/web/blueprints/data_and_tools/blueprint.py
@@ -30,8 +30,8 @@ def resources_index(page=1):
     page = max(1, page)  # Ensure page is at least 1
     per_page = 50  # Number of resources per page
 
-    # Get all resources
-    all_resources_raw = ResourceRepository(db_instance).all()
+    # Get all resources from the view that includes joined preview information
+    all_resources_raw = ResourceRepository(db_instance).all_previews()
 
     # Convert to dot notation objects
     all_resources = [DotDict(resource) for resource in all_resources_raw]

--- a/src/americas_essential_data/web/blueprints/data_and_tools/blueprint.py
+++ b/src/americas_essential_data/web/blueprints/data_and_tools/blueprint.py
@@ -3,6 +3,7 @@ from flask import Blueprint, render_template
 from ...app import db_instance
 from ...data_access.resource import ResourceRepository
 from ...data_access.resource_status import ResourceStatusRepository
+from ...data_access.collection import CollectionRepository
 from ...lib.dotdict import DotDict
 
 
@@ -65,4 +66,49 @@ def view_resource(resource_id: str):
         "data_and_tools/resources/view_resource.html.jinja",
         resource=resource[0],
         status_history=status_history,
+    )
+
+
+@data_and_tools.route("/collections/")
+@data_and_tools.route("/collections/<int:page>")
+def collections_index(page=1):
+    # Default to page 1 if not specified
+    page = max(1, page)  # Ensure page is at least 1
+    per_page = 50  # Number of results per page
+
+    # Get all collections from the view that includes joined preview information
+    all_collections_raw = CollectionRepository(db_instance).all_previews()
+
+    # Convert to dot notation objects
+    all_collections = [DotDict(collection) for collection in all_collections_raw]
+
+    # Calculate pagination
+    total_collections = len(all_collections)
+    total_pages = (total_collections + per_page - 1) // per_page  # Ceiling division
+
+    # Slice the results for the current page
+    start_idx = (page - 1) * per_page
+    end_idx = min(start_idx + per_page, total_collections)
+    current_collections = all_collections[start_idx:end_idx]
+
+    return render_template(
+        "data_and_tools/collections/index.html.jinja",
+        collections=current_collections,
+        current_page=page,
+        total_pages=total_pages,
+        total_collections=total_collections,
+    )
+
+
+@data_and_tools.route("/collections/<collection_id>")
+def view_collection(collection_id: str):
+    collection = CollectionRepository(db_instance).find_by_id(collection_id)
+    resource_list = CollectionRepository(db_instance).find_resources_by_collection_id(
+        collection_id
+    )
+
+    return render_template(
+        "data_and_tools/resources/view_resource.html.jinja",
+        collection=collection[0],
+        resource_list=resource_list,
     )

--- a/src/americas_essential_data/web/blueprints/data_and_tools/templates/data_and_tools/collections/_partials/collection_preview.html.jinja
+++ b/src/americas_essential_data/web/blueprints/data_and_tools/templates/data_and_tools/collections/_partials/collection_preview.html.jinja
@@ -1,0 +1,32 @@
+<article class="collection-preview">
+  <header class="collection-preview__heading">
+    <h2 class="collection-preview__title">{{ collection.name }}</h2>
+    <span class="collection-preview__detail-link"><a href="{{ url_for('data-and-tools.view_collection', collection_id=collection.id) }}">See more</a></span>
+  </header>
+  <table class="collection-preview__metadata">
+    <tbody>
+      {% if collection.primary_url %}
+      <tr>
+        <th class="collection-preview__field-header">Primary URL</th>
+        <td>
+          <a href="{{ collection.primary_url }}">{{ collection.primary_url }}</a>
+        </td>
+      </tr>
+      {% endif %}
+      <tr>
+        <th class="collection-preview__field-header">Resources included</th>
+        <td>{{ collection.linked_resources_count }}</td>
+      </tr>
+      <tr>
+        <th class="collection-preview__field-header">Created at</th>
+        <td>{{ collection.created_at }}</td>
+      </tr>
+      {% if collection.latest_status %}
+        <tr>
+          <th class="collection-preview__field-header">Latest status</th>
+          <td>{{ collection.latest_status }}, checked at {{ collection.latest_status_timestamp }}</td>
+        </tr>
+      {% endif %}
+    </tbody>
+  </table>
+</article>

--- a/src/americas_essential_data/web/blueprints/data_and_tools/templates/data_and_tools/collections/index.html.jinja
+++ b/src/americas_essential_data/web/blueprints/data_and_tools/templates/data_and_tools/collections/index.html.jinja
@@ -1,0 +1,51 @@
+{% extends "_shared/page.html.jinja" %}
+
+{% block title %}
+  Data Sources
+{% endblock title %}
+
+{% block head %}
+  <link rel="stylesheet"
+        href="{{ url_for('data-and-tools.static', filename='styles/collections.css') }}" />
+{% endblock head %}
+
+{% block main %}
+  <header class="collection-list__header flex-grid">
+    <h1 class="collection-list__title">Data collections</h1>
+    <span class="collection-list__stats">Showing {{ collections|length }} of {{ total_collections }} collections</span>
+  </header>
+
+  <section class="collection-list__items flex-grid">
+    {% for collection in collections %}
+      {% include "data_and_tools/collections/_partials/collection_preview.html.jinja" %}
+    {% endfor %}
+  </section>
+
+  {% if total_pages > 1 %}
+    <footer class="collection-list__footer">
+      <nav class="pagination">
+        {% if current_page > 1 %}
+          <a href="{{ url_for('data-and-tools.collections_index', page=current_page-1) }}"
+             class="pagination__prev">Previous</a>
+        {% endif %}
+
+        <ol class="pagination__pages">
+          {% for p in range(1, total_pages + 1) %}
+            {% if p == current_page %}
+              <li class="pagination__page pagination__page--current">{{ p }}</li>
+            {% else %}
+              <li class="pagination__page">
+                <a href="{{ url_for('data-and-tools.collections_index', page=p) }}">{{ p }}</a>
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ol>
+
+        {% if current_page < total_pages %}
+          <a href="{{ url_for('data-and-tools.collections_index', page=current_page+1) }}"
+             class="pagination__next">Next</a>
+        {% endif %}
+      </nav>
+    </footer>
+  {% endif %}
+{% endblock main %}

--- a/src/americas_essential_data/web/blueprints/data_and_tools/templates/data_and_tools/collections/view_collection.html.jinja
+++ b/src/americas_essential_data/web/blueprints/data_and_tools/templates/data_and_tools/collections/view_collection.html.jinja
@@ -1,0 +1,56 @@
+{% extends "_shared/page.html.jinja" %}
+
+{% block title %}
+  {{ collection.name }}
+{% endblock title %}
+
+{% block head %}
+  <link rel="stylesheet"
+        href="{{ url_for('data-and-tools.static', filename='styles/collections.css') }}" />
+{% endblock head %}
+
+{% block main %}
+  <div class="collection-detail__wrapper flex-grid">
+    <header class="collection-detail__heading">
+      <h1 class="collection-detail__title">{{ collection.name }}</h1>
+      <a href={{ url_for("data-and-tools.collections_index") }}>Back to all collections</a>
+    </header>
+    <section class="collection-detail">
+      {% if collection.description %}
+        <p>{{ collection.description }}</p>
+      {% endif %}
+      <table class="collection-detail__metadata">
+        <tbody>
+          {% if collection.primary_url%}
+          <tr>
+            <th class="collection-preview__field-header">Primary URL</th>
+            <td>
+              <a href="{{ collection.primary_url }}">{{ collection.primary_url }}</a>
+            </td>
+          </tr>
+          {% endif %}
+          {% if collection.omb_control_number%}
+          <tr>
+            <th class="collection-detail__field-header">OMB Control Number</th>
+            <td>{{ collection.omb_control_number }}</td>
+          </tr>
+          {% endif %}
+          <tr>
+            <th class="collection-detail__field-header">Created at</th>
+            <td>{{ collection.created_at }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="collection-detail__resources-list">
+      {% if resource_list %}
+        <h2 class="collection-detail__resources-list-title">View {resources_list|length} associated resources</h2>
+          <section class="resource-list__items flex-grid">
+            {% for resource in resource_list %}
+              {% include "data_and_tools/resources/_partials/resource_preview.html.jinja" %}
+            {% endfor %}
+          </section>
+      {% endif %}
+    </section>
+  </div>
+{% endblock main %}

--- a/src/americas_essential_data/web/blueprints/data_and_tools/templates/data_and_tools/resources/_partials/resource_preview.html.jinja
+++ b/src/americas_essential_data/web/blueprints/data_and_tools/templates/data_and_tools/resources/_partials/resource_preview.html.jinja
@@ -19,6 +19,12 @@
         <th class="resource-preview__field-header">Created at</th>
         <td>{{ resource.created_at }}</td>
       </tr>
+      {% if resource.latest_status %}
+        <tr>
+          <th class="resource-preview__field-header">Latest status</th>
+          <td>{{ resource.latest_status }}, checked at {{ resource.latest_status_timestamp }}</td>
+        </tr>
+      {% endif %}
     </tbody>
   </table>
 </article>

--- a/src/americas_essential_data/web/data_access/collection.py
+++ b/src/americas_essential_data/web/data_access/collection.py
@@ -1,0 +1,51 @@
+from .db import DatabaseInstance
+
+
+class CollectionRepository:
+    def __init__(self, db: DatabaseInstance):
+        self.db = db
+        pass
+
+    def all(self):
+        return self.db.query(
+            """
+            SELECT * FROM collections;
+            """
+        )
+
+    def find_by_id(self, id: str):
+        return self.db.query(
+            """
+            SELECT * FROM collections WHERE id = ?;
+            """,
+            [id],
+        )
+
+    def all_previews(self):
+        return self.db.query(
+            """
+            SELECT * FROM v_collection_previews;
+            """
+        )
+
+    def find_resources_by_collection_id(self, collection_id: str):
+        return self.db.query(
+            """
+            WITH linkages AS (
+                SELECT
+                    collection_id,
+                    resource_id,
+                    is_primary
+                FROM collections_resources
+                WHERE collection_id = ?
+            )
+            SELECT 
+                resources.*,
+                linkages.is_primary 
+            FROM resources
+            LEFT JOIN
+                linkages
+                ON resources.id = linkages.resource_id;
+            """,
+            [collection_id],
+        )

--- a/src/americas_essential_data/web/data_access/resource.py
+++ b/src/americas_essential_data/web/data_access/resource.py
@@ -20,3 +20,10 @@ class ResourceRepository:
             """,
             [id],
         )
+
+    def all_previews(self):
+        return self.db.query(
+            """
+            SELECT * FROM v_resource_previews
+            """
+        )

--- a/src/americas_essential_data/web/data_access/resource_status.py
+++ b/src/americas_essential_data/web/data_access/resource_status.py
@@ -6,6 +6,7 @@ class ResourceStatusRepository:
         self.db = db
 
     def find_latest_changes(self):
+        # TODO: Swap this out with read of the new materialized view?
         return [
             dict(
                 dataset="Workplace Fatality Investigations Data",


### PR DESCRIPTION
Initial set of functionality to add new pages and asset types to populate `Collections` into the web app, including:

- [ ] Data Index Landing Page info
- [ ] Collections index page
- [ ] Collections detail page (including list of linked Resources)
- [ ] Nav changes

Not yet ready before merging:
- Styles -- a lot of the content was populated here by just using find-and-replace in the `resources` parts that already exist for the app, but there's not yet a `collections.css` which will be needed.